### PR TITLE
fix(workflows): remove subIssues GraphQL field blocked by PAT restriction

### DIFF
--- a/.github/workflows/enhanced-triage.yml
+++ b/.github/workflows/enhanced-triage.yml
@@ -97,7 +97,6 @@ jobs:
                             id number title body state
                             repository { name nameWithOwner }
                             labels(first: 10) { nodes { name } }
-                            subIssues(first: 20) { nodes { id number } }
                           }
                         }
                       }
@@ -236,8 +235,6 @@ jobs:
               const content = item.content;
               if (!content || !content.title) return false;
               if (item.status?.name !== 'Triage') return false;
-              // Skip if already triaged (has sub-issues)
-              if (content.subIssues?.nodes?.length > 0) return false;
               // Skip if already has 'triaged' label
               if (content.labels?.nodes?.some(l => l.name === 'triaged')) return false;
               return true;

--- a/.github/workflows/tracking-sync.yml
+++ b/.github/workflows/tracking-sync.yml
@@ -65,22 +65,6 @@ jobs:
                             state
                             repository { name nameWithOwner }
                             labels(first: 10) { nodes { name } }
-                            subIssues(first: 20) {
-                              nodes {
-                                id
-                                number
-                                title
-                                state
-                                repository { name nameWithOwner }
-                              }
-                            }
-                            trackedInIssues(first: 5) {
-                              nodes {
-                                id
-                                number
-                                repository { name nameWithOwner }
-                              }
-                            }
                           }
                         }
                       }
@@ -134,35 +118,51 @@ jobs:
             const allItems = await getProjectItems();
             console.log(`Found ${allItems.length} project items`);
 
-            // Find tracking issues (in bd4-intake with 'tracking' label and sub-issues)
+            // Find tracking issues (in bd4-intake with 'tracking' label)
             const trackingItems = allItems.filter(item => {
               const content = item.content;
               if (!content) return false;
               const isIntake = content.repository?.name === 'bd4-intake';
               const hasTracking = content.labels?.nodes?.some(l => l.name === 'tracking');
-              const hasSubs = content.subIssues?.nodes?.length > 0;
-              return isIntake && hasTracking && hasSubs;
+              return isIntake && hasTracking;
             });
 
-            console.log(`Found ${trackingItems.length} tracking issues with sub-issues`);
+            console.log(`Found ${trackingItems.length} tracking issues`);
 
             for (const tracking of trackingItems) {
               const trackingStatus = tracking.status?.name;
-              const subIssues = tracking.content.subIssues.nodes;
               const trackingNum = tracking.content.number;
 
-              console.log(`\n#${trackingNum} "${tracking.content.title}" [${trackingStatus}] — ${subIssues.length} sub-issues`);
+              console.log(`\n#${trackingNum} "${tracking.content.title}" [${trackingStatus}]`);
 
-              // Get sub-issue statuses from project
-              const subStatuses = [];
-              for (const sub of subIssues) {
-                const subItem = findProjectItem(allItems, sub.id);
-                const subStatus = subItem?.status?.name || (sub.state === 'CLOSED' ? 'Done' : 'Backlog');
-                subStatuses.push({ ...sub, projectItem: subItem, status: subStatus });
-                console.log(`  Sub #${sub.number} (${sub.repository.name}) [${subStatus}]`);
+              // Find sub-issues via search (subIssues GraphQL field requires GitHub App token)
+              let searchItems = [];
+              try {
+                const searchRes = await github.rest.search.issuesAndPullRequests({
+                  q: `org:TractionBD "bd4-intake#${trackingNum}" in:body is:issue -repo:TractionBD/bd4-intake`,
+                  per_page: 20
+                });
+                searchItems = searchRes.data.items;
+              } catch (e) {
+                console.log(`  Search failed: ${e.message}`);
+                continue;
               }
 
-              // RULE 1: When tracking is Ready, promote sub-issues from Backlog/Design to Ready
+              if (searchItems.length === 0) {
+                console.log(`  No sub-issues found via search`);
+                continue;
+              }
+
+              const subStatuses = [];
+              for (const sub of searchItems) {
+                const repoName = sub.repository_url.split('/').pop();
+                const subItem = allItems.find(i => i.content?.id === sub.node_id);
+                const subStatus = subItem?.status?.name || (sub.state === 'closed' ? 'Done' : 'Backlog');
+                subStatuses.push({ ...sub, repoName, projectItem: subItem, status: subStatus });
+                console.log(`  Sub #${sub.number} (${repoName}) [${subStatus}]`);
+              }
+
+              // RULE 1: When tracking is Ready, promote sub-issues from Backlog/Design/Triage to Ready
               if (trackingStatus === 'Ready') {
                 for (const sub of subStatuses) {
                   if (sub.projectItem && PROMOTABLE_TO_READY.has(sub.status)) {
@@ -172,8 +172,7 @@ jobs:
                 }
               }
 
-              // RULE 2: If any sub-issue is In Progress (or beyond), move tracking to In Progress
-              // Only if tracking is currently behind In Progress
+              // RULE 2: If any sub-issue is In Progress or beyond, move tracking to In Progress
               const anyInProgressOrBeyond = subStatuses.some(s =>
                 STATUS_ORDER[s.status] >= STATUS_ORDER['In Progress'] && s.status !== 'Done'
               );
@@ -187,7 +186,6 @@ jobs:
               if (allDone && trackingStatus !== 'Done') {
                 console.log(`  Moving tracking #${trackingNum} → Done (all sub-issues complete)`);
                 await setProjectItemStatus(tracking.id, 'Done');
-                // Also close the GitHub issue
                 await github.rest.issues.update({
                   owner: 'TractionBD',
                   repo: 'bd4-intake',


### PR DESCRIPTION
## Summary

- **enhanced-triage**: removes `subIssues(first: 20)` from the `getProjectItems()` GraphQL query and drops the now-redundant `subIssues?.nodes?.length > 0` guard in the triage filter (the `triaged` label check is sufficient to prevent re-processing)
- **tracking-sync**: removes both `subIssues` and `trackedInIssues` blocks from the GraphQL query, replaces the sub-issue lookup with a REST search on `"bd4-intake#N" in:body` so the loop body no longer depends on PAT-gated GraphQL fields

## Root cause

GitHub now requires a GitHub App token for the `subIssues` and `trackedInIssues` GraphQL fields. The `CROSS_REPO_TOKEN` PAT receives `FORBIDDEN` errors on every run, leaving 25+ intake issues stuck in Triage since 2026-04-24.

## Test plan

- [ ] Manually trigger **Enhanced Triage** (`workflow_dispatch`) — confirm run completes without GraphQL FORBIDDEN errors
- [ ] Manually trigger **Tracking Issue Status Sync** (`workflow_dispatch`) — confirm run completes without GraphQL FORBIDDEN errors and that tracking issues with sub-issues (identified via body search) receive correct status promotions
- [ ] Verify a new intake issue placed in Triage status gets picked up and triaged on the next cycle
- [ ] Verify a tracking issue whose sub-issues are all Done gets moved to Done and closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update GitHub workflows to stop using PAT-restricted GraphQL sub-issue fields and rely on labels plus REST search instead.

New Features:
- Support discovering tracking sub-issues via REST issue search based on tracking issue references in bodies.

Bug Fixes:
- Prevent tracking-sync workflow failures caused by forbidden GraphQL subIssues and trackedInIssues fields.
- Ensure enhanced-triage no longer depends on the subIssues GraphQL field so runs complete without authorization errors.

Enhancements:
- Simplify enhanced-triage item filtering to rely on the triaged label instead of sub-issue presence.
- Expand promotion logic to treat Triage sub-issues as promotable to Ready in the tracking-sync workflow.

CI:
- Adjust tracking-sync and enhanced-triage workflow GraphQL queries to remove use of subIssues and trackedInIssues fields that now require GitHub App tokens.