### PR TITLE
fix(triage): suppress run summary Slack when nothing actionable happened

### DIFF
--- a/.github/workflows/enhanced-triage.yml
+++ b/.github/workflows/enhanced-triage.yml
@@ -692,8 +692,11 @@ jobs:
             }
 
             // === RUN SUMMARY ===
-            const total = Object.values(summary).reduce((a, b) => a + b, 0);
-            if (total > 0) {
+            // Only post the summary when something was actually triaged or errored.
+            // Routine no-ops (kicked-to-design, duplicate-skips, already-fixed flags)
+            // are visible in the per-item Slack pings + workflow logs; no need to
+            // also page the channel with a "ran but nothing notable" message.
+            if (summary.triaged > 0 || summary.errored > 0) {
               await notifySlack(
                 `🤖 *Enhanced Triage run complete*\n` +
                 `Triaged: ${summary.triaged} · ` +


### PR DESCRIPTION
Only post the end-of-run summary when `summary.triaged > 0` or `summary.errored > 0`. Removes noise from runs where every item was kicked to Design / flagged as duplicate / flagged as already-fixed (those signals are still surfaced via per-item Slack pings).

## Summary by Sourcery

Adjust enhanced triage workflow behavior and heuristics to reduce noise, improve duplicate/already-fixed detection, and refine how intake issues are translated into canonical work items and Slack notifications.

New Features:
- Add heuristics to detect possible duplicates via CodeRabbit comments and to flag issues likely already fixed by recently merged PRs across core repos.
- Introduce single-repo canonicalization flow that creates a single canonical issue in the target repo and closes the intake issue when appropriate.
- Add run-level triage summary with per-category counts, only posting to Slack when items were triaged or errors occurred.

Bug Fixes:
- Prevent re-triaging or acting on intake issues that are already closed.
- Make project field updates more robust by combining add-to-project and Status/Priority setting into a single helper with better error handling.

Enhancements:
- Refine LLM triage prompt and guidance around repo selection, design involvement, and single-repo defaults.
- Improve handling of design-needed items by sending them back to Design with clearer comments and status changes instead of creating sub-issues.
- Enhance idempotency for multi-repo sub-issue creation by detecting and reusing existing sub-issues that already reference the intake.
- Standardize label usage (bug vs feature, priority, tracking/triaged) and ensure parent and sub-issues are consistently added to the project with Ready status.
- Add tokenization utilities and stopword filtering to support word-overlap matching logic, and log structured run summaries for observability.

CI:
- Clarify that the enhanced triage workflow is currently disabled in the GitHub Actions UI and that changes are staged for future re-enablement.